### PR TITLE
Update chapter data deletion flow

### DIFF
--- a/src/ultimatemangareadercore.cpp
+++ b/src/ultimatemangareadercore.cpp
@@ -176,11 +176,13 @@ void UltimateMangaReaderCore::deleteChapterData(QSharedPointer<MangaInfo> info, 
     QDir dir(CONF.mangaimagesdir(info->hostname, info->title));
     for (const QFileInfo &fi : dir.entryInfoList(QStringList{QString("%1_*").arg(chapter)}, QDir::Files))
         QFile::remove(fi.absoluteFilePath());
+    emit chapterDataDeleted(info);
 }
 
 void UltimateMangaReaderCore::deleteAllChapterData(QSharedPointer<MangaInfo> info)
 {
     removeDir(CONF.mangaimagesdir(info->hostname, info->title));
+    emit chapterDataDeleted(info);
 }
 
 void UltimateMangaReaderCore::deleteReadChapterData(QSharedPointer<MangaInfo> info)
@@ -188,6 +190,7 @@ void UltimateMangaReaderCore::deleteReadChapterData(QSharedPointer<MangaInfo> in
     ReadingProgress progress(info->hostname, info->title);
     for (int c = 0; c < progress.index.chapter; ++c)
         deleteChapterData(info, c);
+    emit chapterDataDeleted(info);
 }
 
 void UltimateMangaReaderCore::updateMangaLists(QSharedPointer<UpdateProgressToken> progressToken)

--- a/src/ultimatemangareadercore.h
+++ b/src/ultimatemangareadercore.h
@@ -63,6 +63,8 @@ signals:
 
     void downloadCacheCleared(ClearDownloadCacheLevel level);
 
+    void chapterDataDeleted(QSharedPointer<MangaInfo> info);
+
     void error(const QString &error);
 
     void timeTick();

--- a/src/widgets/mainwidget.cpp
+++ b/src/widgets/mainwidget.cpp
@@ -104,6 +104,8 @@ MainWidget::MainWidget(QWidget *parent)
 
     QObject::connect(core, &UltimateMangaReaderCore::downloadCacheCleared,
                      [this]() { ui->mangaReaderWidget->clearCache(); });
+    QObject::connect(core, &UltimateMangaReaderCore::chapterDataDeleted,
+                     ui->mangaInfoWidget, &MangaInfoWidget::refreshInfos);
 
     // MangaController
     QObject::connect(core->mangaController, &MangaController::currentMangaChanged,

--- a/src/widgets/mangainfowidget.cpp
+++ b/src/widgets/mangainfowidget.cpp
@@ -138,6 +138,11 @@ void MangaInfoWidget::updateCover()
     }
 }
 
+void MangaInfoWidget::refreshInfos()
+{
+    updateInfos();
+}
+
 void MangaInfoWidget::updateInfos()
 {
     selectedChapter = -1;

--- a/src/widgets/mangainfowidget.h
+++ b/src/widgets/mangainfowidget.h
@@ -38,6 +38,7 @@ signals:
 public slots:
     void updateManga(bool newchapters);
     void updateCover();
+    void refreshInfos();
 
 private slots:
     void on_toolButtonAddFavorites_clicked();


### PR DESCRIPTION
## Summary
- emit `chapterDataDeleted` signal when chapter data is removed
- add `refreshInfos` slot to `MangaInfoWidget` to update chapter list
- hook the new signal in `MainWidget` so deletion refreshes the UI immediately

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68725a1c53a483308fbadf0917300efe