### PR TITLE
Add language filter refresh for MangaDex

### DIFF
--- a/src/mangasources/mangadex.cpp
+++ b/src/mangasources/mangadex.cpp
@@ -34,7 +34,7 @@ MangaDex::MangaDex(NetworkManager *dm) : AbstractMangaSource(dm)
     name = "MangaDex";
     apiUrl = "https://api.mangadex.org";
     baseUrl = apiUrl;
-    languageFilter = "en";
+    languageFilter = "";
 
     networkManager->addCookie(".mangadex.org", "mangadex_h_toggle", "1");
     networkManager->addCookie(".mangadex.org", "mangadex_title_mode", "2");

--- a/src/widgets/mangainfowidget.cpp
+++ b/src/widgets/mangainfowidget.cpp
@@ -7,6 +7,7 @@
 #include <QToolButton>
 #include <QMenu>
 #include <QComboBox>
+#include "mangasources/mangadex.h"
 #include "ui_mangainfowidget.h"
 
 MangaInfoWidget::MangaInfoWidget(QWidget *parent)
@@ -269,5 +270,17 @@ void MangaInfoWidget::on_comboBoxLanguage_currentIndexChanged(int index)
     if (!languageBox->isVisible())
         return;
     selectedLanguage = languageBox->itemText(index);
+
+    if (!currentmanga.isNull())
+    {
+        auto *dex = dynamic_cast<MangaDex *>(currentmanga->mangaSource);
+        if (dex)
+        {
+            QString lang = selectedLanguage == "All" ? QString() : selectedLanguage;
+            dex->setLanguageFilter(lang);
+            dex->updateMangaInfoAsync(currentmanga, false);
+        }
+    }
+
     updateInfos();
 }


### PR DESCRIPTION
## Summary
- add MangaDex include to MangaInfoWidget
- call MangaDex::setLanguageFilter when language selection changes
- refresh chapter list using updateMangaInfoAsync
- default MangaDex language filter to empty string

## Testing
- `clang-format -i src/widgets/mangainfowidget.cpp src/mangasources/mangadex.cpp` *(fails: command not found? Wait we ran it though. But we can't compile due to environment)*

------
https://chatgpt.com/codex/tasks/task_b_68725a166d7c833090fb95a0208e3822