### PR TITLE
Serialize manga languages

### DIFF
--- a/src/mangachapter.cpp
+++ b/src/mangachapter.cpp
@@ -15,7 +15,7 @@ MangaChapter::MangaChapter(const QString &title, const QString &url)
 QDataStream &operator<<(QDataStream &str, const MangaChapter &m)
 {
     str << m.chapterTitle << m.chapterUrl << m.pagesLoaded << m.pageUrlList << m.imageUrlList
-        << m.chapterNumber;
+        << m.chapterNumber << m.language;
 
     return str;
 }
@@ -24,6 +24,11 @@ QDataStream &operator>>(QDataStream &str, MangaChapter &m)
 {
     str >> m.chapterTitle >> m.chapterUrl >> m.pagesLoaded >> m.pageUrlList >> m.imageUrlList >>
         m.chapterNumber;
+
+    if (!str.atEnd())
+        str >> m.language;
+    else
+        m.language.clear();
 
     return str;
 }

--- a/src/mangainfo.cpp
+++ b/src/mangainfo.cpp
@@ -18,6 +18,10 @@ QSharedPointer<MangaInfo> MangaInfo::deserialize(AbstractMangaSource *mangasourc
     QDataStream in(&file);
     in >> mi->hostname >> mi->title >> mi->url >> mi->author >> mi->artist >> mi->releaseYear >> mi->status >>
         mi->genres >> mi->summary >> mi->coverUrl >> mi->coverPath >> mi->chapters;
+    if (!in.atEnd())
+        in >> mi->languages;
+    else
+        mi->languages.clear();
 
     file.close();
 
@@ -32,7 +36,7 @@ void MangaInfo::serialize()
 
     QDataStream out(&file);
     out << hostname << title << url << author << artist << releaseYear << status << genres << summary
-        << coverUrl << coverPath << chapters;
+        << coverUrl << coverPath << chapters << languages;
 
     file.close();
 }


### PR DESCRIPTION
## Summary
- include language in MangaChapter stream operators
- save and load MangaInfo.languages
- handle missing values for backwards compatibility

## Testing
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_b_68725a1468908330b03b9a5dc0c76aec